### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Testbase.yml
+++ b/.github/workflows/Testbase.yml
@@ -18,9 +18,9 @@ jobs:
       QT_DEBUG_PLUGINS: 1
     steps:
       - name: Set up Python ${{ inputs.python }}
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
       - name: Install dependencies
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ inputs.python }}
       - name: Install package

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -36,10 +36,10 @@ jobs:
           echo "plugin_name=$(echo '${{ github.repository }}' | cut -d'/' -f2)" >> $GITHUB_ENV
 
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
  
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload compatibility report
         if: failure()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v7.0.0
         with:
           name:  
           path: 'import_report_tests_${{ env.plugin_name }}_None.txt'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v5.4.0
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v7.0.0](https://github.com/actions/upload-artifact/releases/tag/v7.0.0)** on 2026-02-26T18:21:17Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0)** on 2026-01-22T03:04:50Z
